### PR TITLE
Improve window tiling arrangement

### DIFF
--- a/arrangeWindows@sun.wxg@gmail.com/extension.js
+++ b/arrangeWindows@sun.wxg@gmail.com/extension.js
@@ -221,7 +221,6 @@ class ArrangeMenu extends PanelMenu.Button {
             for (let cellJ = 0; cellJ < gridCells.length; cellJ ++) {
                 const cell = gridCells[cellJ];
                 global.log(`cell.cX: ${cell.centerX} cell.x: ${cell.x}`);
-                // TODO: What if minimised?
                 const dist = Math.sqrt((windowCenterX - cell.centerX) ** 2 +
                     (windowCenterY - cell.centerY) ** 2);
                 global.log(`before sqrt: ${(windowCenterX - cell.centerX) ** 2 + (windowCenterY - cell.centerY) ** 2}`);
@@ -236,6 +235,7 @@ class ArrangeMenu extends PanelMenu.Button {
         function moveWindow(wind, cell) {
             const win = wind.get_meta_window();
             win.unmaximize(Meta.MaximizeFlags.BOTH);
+            win.unminimize();
             win.move_resize_frame(false, cell.x, cell.y, cell.w, cell.h);
         }
 

--- a/arrangeWindows@sun.wxg@gmail.com/extension.js
+++ b/arrangeWindows@sun.wxg@gmail.com/extension.js
@@ -194,13 +194,13 @@ class ArrangeMenu extends PanelMenu.Button {
             if (row + 1 === rowNumber && numLastRow !== 0) {
                 // In the last row, recalculate width so that they fill the screen
                 let gridWidthLastRow = Math.floor(workArea.width / numLastRow);
-                cell.x = col * gridWidthLastRow;
+                cell.x = workArea.x + col * gridWidthLastRow;
                 cell.w = gridWidthLastRow;
             } else {
-                cell.x = col * gridWidth;
+                cell.x = workArea.x + col * gridWidth;
                 cell.w = gridWidth;
             }
-            cell.y = row * gridHeight;
+            cell.y = workArea.y + row * gridHeight;
             cell.h = gridHeight;
             cell.centerX = cell.x + cell.w / 2;
             cell.centerY = cell.y + cell.h / 2;

--- a/arrangeWindows@sun.wxg@gmail.com/extension.js
+++ b/arrangeWindows@sun.wxg@gmail.com/extension.js
@@ -194,7 +194,6 @@ class ArrangeMenu extends PanelMenu.Button {
             if (row + 1 === rowNumber && numLastRow !== 0) {
                 // In the last row, recalculate width so that they fill the screen
                 let gridWidthLastRow = Math.floor(workArea.width / numLastRow);
-                global.log(numLastRow, gridWidthLastRow);
                 cell.x = col * gridWidthLastRow;
                 cell.w = gridWidthLastRow;
             } else {
@@ -236,7 +235,7 @@ class ArrangeMenu extends PanelMenu.Button {
         const windowIsToMove = new Set(windows.keys());
         const cellJsToFill = new Set(gridCells.keys());
 
-        // Add windows, closest to grid position first.
+        // Move windows, closest to grid position first.
         for (let i = 0; i < windows.length; i ++) {
             if (windowIsToMove.size !== cellJsToFill.size)
                 throw Error('Expected to assign one cell per window');
@@ -253,7 +252,6 @@ class ArrangeMenu extends PanelMenu.Button {
                 )
             );
             moveWindow(windows[minI], gridCells[minJ]);
-            global.log('Deleting from windowIsToMove');
             windowIsToMove.delete(minI);
             cellJsToFill.delete(minJ);
         }

--- a/arrangeWindows@sun.wxg@gmail.com/extension.js
+++ b/arrangeWindows@sun.wxg@gmail.com/extension.js
@@ -205,7 +205,6 @@ class ArrangeMenu extends PanelMenu.Button {
             cell.h = gridHeight;
             cell.centerX = cell.x + cell.w / 2;
             cell.centerY = cell.y + cell.h / 2;
-            global.log(`cell.cX: ${cell.centerX} cell.x: ${cell.x} cell.cY: ${cell.centerY} cell.x: ${cell.y}`);
             gridCells.push(cell);
         }
 
@@ -216,17 +215,11 @@ class ArrangeMenu extends PanelMenu.Button {
             const win = windows[windowI];
             const windowCenterX = win.x + win.width / 2;
             const windowCenterY = win.y + win.height / 2;
-            global.log(`win.cX: ${windowCenterX}, win.cY: ${windowCenterY}`);
             distances[windowI] = [];
             for (let cellJ = 0; cellJ < gridCells.length; cellJ ++) {
                 const cell = gridCells[cellJ];
-                global.log(`cell.cX: ${cell.centerX} cell.x: ${cell.x}`);
                 const dist = Math.sqrt((windowCenterX - cell.centerX) ** 2 +
                     (windowCenterY - cell.centerY) ** 2);
-                global.log(`before sqrt: ${(windowCenterX - cell.centerX) ** 2 + (windowCenterY - cell.centerY) ** 2}`);
-                if (dist < 0 || dist > 4000) {
-                    throw Error(`unusual distance ${dist}`);
-                }
                 distances[windowI][cellJ] = dist;
             }
         }
@@ -243,6 +236,7 @@ class ArrangeMenu extends PanelMenu.Button {
         const windowIsToMove = new Set(windows.keys());
         const cellJsToFill = new Set(gridCells.keys());
 
+        // Add windows, closest to grid position first.
         for (let i = 0; i < windows.length; i ++) {
             if (windowIsToMove.size !== cellJsToFill.size)
                 throw Error('Expected to assign one cell per window');
@@ -251,25 +245,17 @@ class ArrangeMenu extends PanelMenu.Button {
             windowIsToMove.forEach(windowI =>
                 cellJsToFill.forEach(cellJ => {
                         if (distances[windowI][cellJ] < minDist) {
-                            global.log(`Updating minDist from ${minDist} to ${distances[windowI][cellJ]}`);
                             minDist = distances[windowI][cellJ];
                             minI = windowI;
                             minJ = cellJ;
-                        } else {
-                            global.log(`${distances[windowI][cellJ]} not less than ${minDist}`)
                         }
                     }
                 )
             );
-
-            if (minI === undefined || minJ === undefined) {
-                throw Error('Expected to define minI and minJ')
-            } else {
-                moveWindow(windows[minI], gridCells[minJ]);
-                global.log('Deleting from windowIsToMove');
-                windowIsToMove.delete(minI);
-                cellJsToFill.delete(minJ);
-            }
+            moveWindow(windows[minI], gridCells[minJ]);
+            global.log('Deleting from windowIsToMove');
+            windowIsToMove.delete(minI);
+            cellJsToFill.delete(minJ);
         }
     }
 


### PR DESCRIPTION
This makes two changes to the tiling window arrangement:
1. When the number of windows on the bottom row is less than in previous rows, the total screen width is used. 
2. Windows are placed into the grid so they enter a grid cell close to where they are currently on the screen. Currently, windows are placed into the grid in order of 'last to have focus' (from top left to bottom right). This leads to windows shuffling if clicking `tile' again after changing focus to a new window.

Here's before:
![before_2](https://user-images.githubusercontent.com/25362777/80542967-e7376d80-89a5-11ea-8053-0bcf9a410c37.gif)


And after:
![after_2](https://user-images.githubusercontent.com/25362777/80542975-ebfc2180-89a5-11ea-8829-69872f19d600.gif)




